### PR TITLE
Harden auth token parsing, validate vote direction, and prevent duplicate users

### DIFF
--- a/app/oauth2.py
+++ b/app/oauth2.py
@@ -33,11 +33,11 @@ def verify_access_token(token: str, credentials_exception):
     try:
 
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        id: str = payload.get("user_id")
-        if id is None:
+        id_value = payload.get("user_id")
+        if id_value is None:
             raise credentials_exception
-        token_data = schemas.TokenData(id=id)
-    except JWTError:
+        token_data = schemas.TokenData(id=str(int(id_value)))
+    except (JWTError, ValueError, TypeError):
         raise credentials_exception
 
     return token_data
@@ -49,6 +49,8 @@ def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(
 
     token = verify_access_token(token, credentials_exception)
 
-    user = db.query(models.User).filter(models.User.id == token.id).first()
+    user = db.query(models.User).filter(models.User.id == int(token.id)).first()
+    if not user:
+        raise credentials_exception
 
     return user

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -19,6 +19,12 @@ def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
     hashed_password = utils.hash(user.password)
     user.password = hashed_password
 
+    existing_user = db.query(models.User).filter(
+        models.User.email == user.email).first()
+    if existing_user:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT,
+                            detail="Email already registered")
+
     new_user = models.User(**user.dict())
     db.add(new_user)
     db.commit()

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -63,4 +63,4 @@ class TokenData(BaseModel):
 
 class Vote(BaseModel):
     post_id: int
-    dir: conint(le=1)
+    dir: conint(ge=0, le=1)


### PR DESCRIPTION
### Motivation
- Enforce valid vote directions to prevent invalid input values being accepted.  
- Harden JWT parsing to safely handle missing or non-integer `user_id` claims.  
- Ensure authenticated requests fail when the token refers to a non-existent user.  
- Provide a user-friendly error when attempting to register an already-registered email.  

### Description
- Update `Vote` schema to require `dir: conint(ge=0, le=1)` so only `0` or `1` are allowed.  
- Improve `verify_access_token` in `app/oauth2.py` to read the `user_id` claim into `id_value`, validate it, normalize it with `str(int(...))`, and catch `JWTError`, `ValueError`, and `TypeError`.  
- Change `get_current_user` to query by `int(token.id)` and raise the credentials `HTTPException` if the user is not found.  
- Add a duplicate-email check in `app/routers/user.py` that returns `HTTP 409 CONFLICT` when an existing email is used to register.  

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948146eeb708330945ec25b0169b80b)