### PR TITLE
Fix partial post updates without overwriting fields

### DIFF
--- a/app/routers/post.py
+++ b/app/routers/post.py
@@ -95,7 +95,7 @@ def delete_post(id: int, db: Session = Depends(get_db), current_user: int = Depe
 
 
 @router.put("/{id}", response_model=schemas.Post)
-def update_post(id: int, updated_post: schemas.PostCreate, db: Session = Depends(get_db), current_user: int = Depends(oauth2.get_current_user)):
+def update_post(id: int, updated_post: schemas.PostUpdate, db: Session = Depends(get_db), current_user: int = Depends(oauth2.get_current_user)):
 
     # cursor.execute("""UPDATE posts SET title = %s, content = %s, published = %s WHERE id = %s RETURNING *""",
     #                (post.title, post.content, post.published, str(id)))
@@ -115,7 +115,10 @@ def update_post(id: int, updated_post: schemas.PostCreate, db: Session = Depends
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN,
                             detail="Not authorized to perform requested action")
 
-    post_query.update(updated_post.dict(), synchronize_session=False)
+    update_data = updated_post.dict(exclude_unset=True, exclude_none=True)
+
+    if update_data:
+        post_query.update(update_data, synchronize_session=False)
 
     db.commit()
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -15,6 +15,12 @@ class PostCreate(PostBase):
     pass
 
 
+class PostUpdate(BaseModel):
+    title: Optional[str] = None
+    content: Optional[str] = None
+    published: Optional[bool] = None
+
+
 class UserOut(BaseModel):
     id: int
     email: EmailStr


### PR DESCRIPTION
### Motivation
- The post update endpoint accepted a full `PostCreate` payload which could inadvertently overwrite existing fields when clients sent partial updates.
- The API needs to support partial updates (PATCH-like semantics) so only provided fields are changed.
- Prevent accidental setting of fields to `null` by ignoring unset or `None` values during updates.

### Description
- Added a new `PostUpdate` schema in `app/schemas.py` with optional `title`, `content`, and `published` fields to represent partial updates.
- Updated the post update handler signature in `app/routers/post.py` to accept `schemas.PostUpdate` instead of `schemas.PostCreate`.
- Compute `update_data = updated_post.dict(exclude_unset=True, exclude_none=True)` and only apply `post_query.update(update_data, synchronize_session=False)` when `update_data` is non-empty to avoid overwriting fields with unset/null values.

### Testing
- Ran the test suite with `pytest -q` to validate behavior, but the run failed due to a missing test dependency: `ModuleNotFoundError: No module named 'httpx'`.
- No further automated tests were executed because the environment lacks the `httpx` package required by `fastapi.testclient`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694816d9a9248330a250c3dc76ab3f56)