### PR TITLE
Update README strategy for Clue/Cluedo goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,23 +33,25 @@ docker-compose -f docker-compose-dev.yml up --build
 
 This will build the API image and start both the API and a Postgres instance.  The API will be available on `http://localhost:8000` with automatic reload enabled.
 
-## Roadmap
+## Strategy to reach the project goals
 
-The project is in a pre-alpha state.  Below is a high‑level set of tasks to transform the template into a Clue/Cluedo assistant.  These will be completed iteratively:
+This project aims to track player knowledge during a game of Clue/Cluedo and predict the correct solution. The most effective path is to build a reliable data model first, then layer the inference engine and API workflows on top of it, and finally harden the system with tests and deployment tooling.
 
-1. **Replace placeholder models** – Introduce domain models for players, cards, hands and suggestions instead of the example `Post`/`Vote` models.  Create migration scripts via Alembic.
-2. **Game state API** – Add routes to
-   - create a game and register players
-   - record dealt cards
-   - log suggestions and showings
-   - expose an endpoint that returns current probability estimates for each card
-3. **Knowledge engine** – Implement logic that analyses logged actions to infer which cards remain possible in the envelope.  This may start simple and later incorporate probability weights.
-4. **Front‑end considerations** – Provide OpenAPI documentation (already enabled by FastAPI) and later design a lightweight UI or API clients.
-5. **Authentication & authorisation** – Reuse the existing OAuth2 utilities to secure the endpoints so that only authorised players can record or view game information.
-6. **Testing** – Extend the `pytest` suite with unit and integration tests for the new models and endpoints.  Continuous Integration can be set up later to run these automatically.
-7. **Container & deployment** – Polish the Dockerfiles and `docker-compose` setups for production (including the provided `nginx` example).  Evaluate hosting options once the API stabilises.
+1. **Define the domain model up front**  
+   Model the game in terms of players, cards, hands, suggestions, showings, and the hidden envelope. Replace the placeholder `Post`/`Vote` models and generate Alembic migrations. This establishes the data backbone for everything else.
+2. **Capture authoritative game events**  
+   Build endpoints that record immutable facts: game creation, player order, dealt cards, suggestions, and which player showed (if any). These events are the input to all inference logic, so treat them as the source of truth.
+3. **Implement deterministic inference first**  
+   Start with rule-based deductions (e.g., if a player showed a card, they must have one of the suggested cards). Only after deterministic rules are solid should you add probability weighting.
+4. **Expose the knowledge state via API**  
+   Provide a read-only endpoint that returns current deductions and probabilities per card and per player. This becomes the main surface for clients or UI to consume.
+5. **Secure and validate inputs**  
+   Reuse OAuth2 utilities and add validation for game state transitions to prevent inconsistent data (e.g., no showing before a suggestion is logged).
+6. **Test the inference engine rigorously**  
+   Expand `pytest` coverage with unit tests for deduction rules and integration tests for common gameplay scenarios. This is the fastest way to ensure correctness as logic grows.
+7. **Polish deployment once the core works**  
+   After the logic is stable, tighten Docker and Compose configs, add environment configuration, and consider production hosting details.
 
 ## Contributing
 
 This repository is currently experimental.  Feel free to open issues or pull requests with ideas or improvements.  As the project matures, contribution guidelines and a code of conduct will be added.
-


### PR DESCRIPTION
### Motivation

- Clarify and replace the generic roadmap with a practical, prioritized strategy to reach the project's goal of tracking player knowledge and predicting the solution.
- Emphasize building a correct domain model as the foundation for inference and API features.
- Encourage capturing authoritative, immutable game events as the source of truth for deductions.
- Promote starting with deterministic rule-based inference before adding probabilistic weighting.

### Description

- Replace the previous `Roadmap` section in `README.md` with a new `Strategy to reach the project goals` section containing a 7-step approach.
- Recommend modeling players, cards, hands, suggestions, showings, and the envelope and creating Alembic migrations for schema changes.
- Add guidance to create immutable event endpoints, expose a read-only knowledge API, and reuse `OAuth2` utilities for validation and security.
- Advise expanding `pytest` coverage for deduction rules and polishing `docker-compose`/deployment once core logic is stable.

### Testing

- No automated tests were executed because this is a documentation-only change.
- The repository contains a `pytest` test suite (runs against a temporary SQLite DB) which was not run for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948195c05808330b5a555b20a117e5a)