### PR TITLE
Add games API and UI landing page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,15 +1,18 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 
 from . import models
 from .database import engine
-from .routers import post, user, auth, vote
+from .routers import post, user, auth, vote, game, ui
 from .config import settings
 
 
 # models.Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
+
+app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
 origins = ["*"]
 
@@ -25,6 +28,8 @@ app.include_router(post.router)
 app.include_router(user.router)
 app.include_router(auth.router)
 app.include_router(vote.router)
+app.include_router(game.router)
+app.include_router(ui.router)
 
 
 @app.get("/")

--- a/app/models.py
+++ b/app/models.py
@@ -36,3 +36,33 @@ class Vote(Base):
         "users.id", ondelete="CASCADE"), primary_key=True)
     post_id = Column(Integer, ForeignKey(
         "posts.id", ondelete="CASCADE"), primary_key=True)
+
+
+class Game(Base):
+    __tablename__ = "games"
+
+    id = Column(Integer, primary_key=True, nullable=False)
+    name = Column(String, nullable=False)
+    status = Column(String, nullable=False, server_default="setup")
+    created_at = Column(TIMESTAMP(timezone=True),
+                        nullable=False, server_default=text('CURRENT_TIMESTAMP'))
+    owner_id = Column(Integer, ForeignKey(
+        "users.id", ondelete="SET NULL"), nullable=True)
+
+    owner = relationship("User")
+    players = relationship("Player", back_populates="game",
+                           cascade="all, delete-orphan")
+
+
+class Player(Base):
+    __tablename__ = "players"
+
+    id = Column(Integer, primary_key=True, nullable=False)
+    game_id = Column(Integer, ForeignKey(
+        "games.id", ondelete="CASCADE"), nullable=False)
+    name = Column(String, nullable=False)
+    seat_order = Column(Integer, nullable=False)
+    created_at = Column(TIMESTAMP(timezone=True),
+                        nullable=False, server_default=text('CURRENT_TIMESTAMP'))
+
+    game = relationship("Game", back_populates="players")

--- a/app/routers/game.py
+++ b/app/routers/game.py
@@ -1,0 +1,92 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import models, schemas, oauth2
+from ..database import get_db
+
+
+router = APIRouter(
+    prefix="/games",
+    tags=["Games"]
+)
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED, response_model=schemas.GameOut)
+def create_game(
+    game: schemas.GameCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(oauth2.get_current_user),
+):
+    new_game = models.Game(name=game.name, owner_id=current_user.id)
+    db.add(new_game)
+    db.commit()
+    db.refresh(new_game)
+    return new_game
+
+
+@router.get("/", response_model=List[schemas.GameOut])
+def list_games(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(oauth2.get_current_user),
+):
+    return db.query(models.Game).filter(models.Game.owner_id == current_user.id).order_by(models.Game.created_at.desc()).all()
+
+
+@router.get("/{game_id}", response_model=schemas.GameDetail)
+def get_game(
+    game_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(oauth2.get_current_user),
+):
+    game = db.query(models.Game).filter(models.Game.id == game_id).first()
+    if not game:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
+    if game.owner_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to view this game")
+    return game
+
+
+@router.post("/{game_id}/players", status_code=status.HTTP_201_CREATED, response_model=schemas.PlayerOut)
+def add_player(
+    game_id: int,
+    player: schemas.PlayerCreate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(oauth2.get_current_user),
+):
+    game = db.query(models.Game).filter(models.Game.id == game_id).first()
+    if not game:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
+    if game.owner_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to edit this game")
+
+    existing_player = db.query(models.Player).filter(
+        models.Player.game_id == game_id,
+        models.Player.seat_order == player.seat_order,
+    ).first()
+    if existing_player:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Seat order already taken for this game",
+        )
+
+    new_player = models.Player(game_id=game_id, name=player.name, seat_order=player.seat_order)
+    db.add(new_player)
+    db.commit()
+    db.refresh(new_player)
+    return new_player
+
+
+@router.get("/{game_id}/players", response_model=List[schemas.PlayerOut])
+def list_players(
+    game_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(oauth2.get_current_user),
+):
+    game = db.query(models.Game).filter(models.Game.id == game_id).first()
+    if not game:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
+    if game.owner_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to view this game")
+    return db.query(models.Player).filter(models.Player.game_id == game_id).order_by(models.Player.seat_order.asc()).all()

--- a/app/routers/ui.py
+++ b/app/routers/ui.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, Depends, Form, Request, status
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from .. import models
+from ..database import get_db
+
+
+router = APIRouter(tags=["UI"])
+templates = Jinja2Templates(directory="app/templates")
+
+
+@router.get("/ui", response_class=HTMLResponse)
+def ui_home(request: Request, db: Session = Depends(get_db)):
+    games = db.query(models.Game).order_by(models.Game.created_at.desc()).all()
+    return templates.TemplateResponse(
+        "index.html",
+        {"request": request, "games": games},
+    )
+
+
+@router.post("/ui/games")
+def ui_create_game(
+    request: Request,
+    name: str = Form(...),
+    db: Session = Depends(get_db),
+):
+    trimmed_name = name.strip()
+    if not trimmed_name:
+        games = db.query(models.Game).order_by(models.Game.created_at.desc()).all()
+        return templates.TemplateResponse(
+            "index.html",
+            {
+                "request": request,
+                "games": games,
+                "error": "Game name cannot be empty.",
+            },
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    new_game = models.Game(name=trimmed_name)
+    db.add(new_game)
+    db.commit()
+    return RedirectResponse(url="/ui", status_code=status.HTTP_303_SEE_OTHER)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, EmailStr
 from datetime import datetime
-from typing import Optional
+from typing import Optional, List
 
 from pydantic.types import conint
 
@@ -70,3 +70,43 @@ class TokenData(BaseModel):
 class Vote(BaseModel):
     post_id: int
     dir: conint(ge=0, le=1)
+
+
+class GameBase(BaseModel):
+    name: str
+
+
+class GameCreate(GameBase):
+    pass
+
+
+class GameOut(GameBase):
+    id: int
+    status: str
+    created_at: datetime
+    owner_id: Optional[int]
+
+    class Config:
+        orm_mode = True
+
+
+class PlayerBase(BaseModel):
+    name: str
+    seat_order: conint(ge=1)
+
+
+class PlayerCreate(PlayerBase):
+    pass
+
+
+class PlayerOut(PlayerBase):
+    id: int
+    game_id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class GameDetail(GameOut):
+    players: List[PlayerOut] = []

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,164 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap");
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Inter", sans-serif;
+  background: radial-gradient(circle at top, #1e1b4b, #0f172a 50%, #020617);
+  color: #e2e8f0;
+  min-height: 100vh;
+}
+
+.page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 48px 24px 80px;
+}
+
+.hero {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 32px;
+  align-items: center;
+  margin-bottom: 48px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 12px;
+  color: #94a3b8;
+  margin-bottom: 12px;
+}
+
+h1 {
+  font-size: clamp(2.5rem, 4vw, 3.6rem);
+  margin-bottom: 16px;
+}
+
+.subtitle {
+  font-size: 1.1rem;
+  max-width: 520px;
+  line-height: 1.7;
+  color: #cbd5f5;
+}
+
+.hero-card {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 20px;
+  padding: 28px;
+  min-width: 280px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.3);
+}
+
+.hero-card h2 {
+  margin-bottom: 16px;
+  font-size: 1.4rem;
+}
+
+.game-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.game-form label {
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.game-form input {
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 12px 14px;
+  background: rgba(15, 23, 42, 0.6);
+  color: #e2e8f0;
+}
+
+.game-form button {
+  margin-top: 8px;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #0f172a;
+  border: none;
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.game-form button:hover {
+  opacity: 0.92;
+}
+
+.error {
+  color: #fca5a5;
+  font-size: 0.85rem;
+}
+
+.content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 24px;
+}
+
+.panel h3 {
+  margin-bottom: 16px;
+  font-size: 1.2rem;
+}
+
+.game-list {
+  list-style: none;
+  display: grid;
+  gap: 12px;
+}
+
+.game-list li {
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(30, 41, 59, 0.6);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.game-list strong {
+  display: block;
+}
+
+.status {
+  display: inline-block;
+  margin-top: 4px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #38bdf8;
+}
+
+.empty {
+  color: #94a3b8;
+}
+
+.info ol {
+  margin-left: 18px;
+  display: grid;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.note {
+  color: #cbd5f5;
+  font-size: 0.95rem;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Got the Clue</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="hero">
+        <div>
+          <p class="eyebrow">Clue • Knowledge Tracker</p>
+          <h1>Got the Clue</h1>
+          <p class="subtitle">
+            Capture every suggestion, track what each player knows, and converge
+            on the solution faster.
+          </p>
+        </div>
+        <div class="hero-card">
+          <h2>Start a game</h2>
+          <form class="game-form" method="post" action="/ui/games">
+            <label for="name">Game name</label>
+            <input id="name" name="name" type="text" placeholder="Friday Night Mystery" />
+            {% if error %}
+              <p class="error">{{ error }}</p>
+            {% endif %}
+            <button type="submit">Create game</button>
+          </form>
+        </div>
+      </header>
+
+      <section class="content">
+        <div class="panel">
+          <h3>Active games</h3>
+          {% if games %}
+            <ul class="game-list">
+              {% for game in games %}
+                <li>
+                  <div>
+                    <strong>{{ game.name }}</strong>
+                    <span class="status">{{ game.status }}</span>
+                  </div>
+                  <small>Game #{{ game.id }}</small>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="empty">No games yet. Start one to begin tracking clues.</p>
+          {% endif %}
+        </div>
+
+        <div class="panel info">
+          <h3>Next steps</h3>
+          <ol>
+            <li>Add players and their seat order.</li>
+            <li>Log every suggestion and reveal.</li>
+            <li>Watch deductions emerge automatically.</li>
+          </ol>
+          <p class="note">
+            API endpoints are still expanding. Games you create here are stored in
+            the same database used by the REST API.
+          </p>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 alembic==1.13.2
 email-validator==2.1.0.post1
 fastapi==0.99.1
+Jinja2==3.1.4
 passlib[bcrypt]==1.7.4
 psycopg2==2.9.9
 pydantic==1.10.15

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,3 +118,23 @@ def test_posts(test_user, session, test_user2):
 
     posts = session.query(models.Post).all()
     return posts
+
+
+@pytest.fixture
+def test_games(test_user, test_user2, session):
+    games_data = [
+        {"name": "Friday Night Mystery", "owner_id": test_user["id"]},
+        {"name": "Weekend Sleuthing", "owner_id": test_user["id"]},
+        {"name": "Second Table", "owner_id": test_user2["id"]},
+    ]
+
+    def create_game_model(game):
+        return models.Game(**game)
+
+    games_map = map(create_game_model, games_data)
+    games = list(games_map)
+
+    session.add_all(games)
+    session.commit()
+
+    return session.query(models.Game).all()

--- a/tests/test_games.py
+++ b/tests/test_games.py
@@ -1,0 +1,61 @@
+def test_create_game(authorized_client, test_user):
+    res = authorized_client.post("/games/", json={"name": "My first game"})
+
+    assert res.status_code == 201
+    data = res.json()
+    assert data["name"] == "My first game"
+    assert data["owner_id"] == test_user["id"]
+    assert data["status"] == "setup"
+
+
+def test_list_games_only_owned(authorized_client, test_games, test_user):
+    res = authorized_client.get("/games/")
+
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data) == 2
+    assert all(game["owner_id"] == test_user["id"] for game in data)
+
+
+def test_get_game_forbidden_other_user(authorized_client, test_games):
+    other_game = test_games[-1]
+    res = authorized_client.get(f"/games/{other_game.id}")
+
+    assert res.status_code == 403
+
+
+def test_add_player_to_game(authorized_client, test_games):
+    game = test_games[0]
+    res = authorized_client.post(
+        f"/games/{game.id}/players",
+        json={"name": "Casey", "seat_order": 1},
+    )
+
+    assert res.status_code == 201
+    data = res.json()
+    assert data["name"] == "Casey"
+    assert data["seat_order"] == 1
+    assert data["game_id"] == game.id
+
+
+def test_add_player_duplicate_seat(authorized_client, test_games):
+    game = test_games[0]
+    res = authorized_client.post(
+        f"/games/{game.id}/players",
+        json={"name": "Casey", "seat_order": 1},
+    )
+    assert res.status_code == 201
+
+    res = authorized_client.post(
+        f"/games/{game.id}/players",
+        json={"name": "Riley", "seat_order": 1},
+    )
+
+    assert res.status_code == 409
+
+
+def test_ui_homepage(client):
+    res = client.get("/ui")
+
+    assert res.status_code == 200
+    assert "Got the Clue" in res.text


### PR DESCRIPTION
### Motivation
- Model games and players to provide a foundation for capturing game state and future inference logic.
- Provide an accessible, attractive UI landing page so users can create and view games without the API explorer.
- Offer authenticated REST endpoints to manage games and players and drive next steps of the Clue knowledge-tracking features.

### Description
- Add `Game` and `Player` SQLAlchemy models in `app/models.py` and corresponding Pydantic schemas in `app/schemas.py` (`GameCreate`, `GameOut`, `PlayerCreate`, `PlayerOut`, `GameDetail`).
- Implement `app/routers/game.py` with endpoints to create/list/get games and to add/list players for a game, enforcing owner authorization and seat-order conflicts.
- Add a simple Jinja2 UI in `app/routers/ui.py` with the template `app/templates/index.html` and stylesheet `app/static/styles.css`, and mount static files in `app/main.py`.
- Add tests in `tests/test_games.py` and extend fixtures in `tests/conftest.py`, and add `Jinja2` to `requirements.txt`.

### Testing
- Ran `pytest -q` in the environment which failed with `ModuleNotFoundError: No module named 'fastapi'` so tests could not execute to completion.
- No automated tests passed in this environment because required packages were not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481a2d1b1483309210da800ca588b1)