### PR TITLE
Add simulation engine with strategy plugins and API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from fastapi.staticfiles import StaticFiles
 
 from . import models
 from .database import engine
-from .routers import post, user, auth, vote, game, ui
+from .routers import post, user, auth, vote, game, ui, simulation
 from .config import settings
 
 
@@ -30,6 +30,7 @@ app.include_router(auth.router)
 app.include_router(vote.router)
 app.include_router(game.router)
 app.include_router(ui.router)
+app.include_router(simulation.router)
 
 
 @app.get("/")

--- a/app/routers/simulation.py
+++ b/app/routers/simulation.py
@@ -1,0 +1,74 @@
+from typing import Dict
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import models, oauth2, schemas
+from ..database import get_db
+from ..simulator import service as simulation_service
+
+
+router = APIRouter(
+    prefix="/games",
+    tags=["Simulations"],
+)
+
+
+@router.post("/{game_id}/simulate", response_model=schemas.SimulationResponse)
+def simulate_game(
+    game_id: int,
+    request: schemas.SimulationRequest,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(oauth2.get_current_user),
+):
+    game = db.query(models.Game).filter(models.Game.id == game_id).first()
+    if not game:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
+    if game.owner_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to simulate this game")
+
+    players = (
+        db.query(models.Player)
+        .filter(models.Player.game_id == game_id)
+        .order_by(models.Player.seat_order.asc())
+        .all()
+    )
+    if not players:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Game has no players to simulate")
+
+    if request.user_player_id not in {player.id for player in players}:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User player not found in this game")
+
+    overrides: Dict[int, str] = {override.player_id: override.strategy_key for override in request.strategy_overrides}
+
+    outcome = simulation_service.run_simulation(
+        players=players,
+        user_player_id=request.user_player_id,
+        user_strategy=request.user_strategy,
+        opponent_strategy=request.opponent_strategy,
+        overrides=overrides,
+        iterations=request.iterations,
+        rounds=request.rounds,
+        include_timeline=request.include_timeline,
+    )
+
+    metrics = outcome.metrics
+
+    return schemas.SimulationResponse(
+        iterations=outcome.iterations,
+        rounds=outcome.rounds,
+        user_player_id=outcome.user_player_id,
+        user_strategy=outcome.user_strategy,
+        opponent_strategy=outcome.opponent_strategy,
+        user_win_percentage=metrics.win_percentage(),
+        strategy_win_percentages={
+            strategy: metrics.win_percentage(strategy)
+            for strategy in metrics.per_strategy_wins
+        },
+        strategy_win_counts=metrics.per_strategy_wins,
+        assignments=[
+            schemas.SimulationAssignmentOut(**assignment)
+            for assignment in simulation_service.serialize_assignments(outcome.assignments)
+        ],
+        timeline=outcome.timeline,
+    )

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -110,3 +110,38 @@ class PlayerOut(PlayerBase):
 
 class GameDetail(GameOut):
     players: List[PlayerOut] = []
+
+
+class SimulationOverride(BaseModel):
+    player_id: int
+    strategy_key: str
+
+
+class SimulationRequest(BaseModel):
+    user_player_id: int
+    user_strategy: str = "conservative"
+    opponent_strategy: str = "random"
+    iterations: conint(ge=1, le=1000) = 100
+    rounds: conint(ge=1, le=50) = 5
+    include_timeline: bool = False
+    strategy_overrides: List[SimulationOverride] = []
+
+
+class SimulationAssignmentOut(BaseModel):
+    player_id: int
+    name: str
+    strategy_key: str
+    is_user: bool
+
+
+class SimulationResponse(BaseModel):
+    iterations: int
+    rounds: int
+    user_player_id: int
+    user_strategy: str
+    opponent_strategy: str
+    user_win_percentage: float
+    strategy_win_percentages: dict
+    strategy_win_counts: dict
+    assignments: List[SimulationAssignmentOut]
+    timeline: Optional[List[dict]] = None

--- a/app/simulator/__init__.py
+++ b/app/simulator/__init__.py
@@ -1,0 +1,21 @@
+from .engine import (
+    BaseEventHook,
+    BaseStrategy,
+    SimulationEngine,
+    SimulationEvent,
+    SimulationPlayer,
+    get_registered_strategies,
+    register_hook,
+    register_strategy,
+)
+
+__all__ = [
+    "BaseEventHook",
+    "BaseStrategy",
+    "SimulationEngine",
+    "SimulationEvent",
+    "SimulationPlayer",
+    "get_registered_strategies",
+    "register_hook",
+    "register_strategy",
+]

--- a/app/simulator/engine.py
+++ b/app/simulator/engine.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Dict, Iterable, List, Optional, Protocol
+
+
+class SimulationEvent(str, Enum):
+    INITIALIZED = "initialized"
+    PLAYER_REGISTERED = "player_registered"
+    GAME_STARTED = "game_started"
+    GAME_COMPLETED = "game_completed"
+    ROUND_STARTED = "round_started"
+    ROUND_COMPLETED = "round_completed"
+
+
+@dataclass(frozen=True)
+class SimulationPlayer:
+    name: str
+    strategy_key: str
+    is_user: bool = False
+
+
+@dataclass(frozen=True)
+class SimulationResult:
+    winner: SimulationPlayer
+    rounds_played: int
+
+
+@dataclass(frozen=True)
+class SimulationRound:
+    number: int
+    scores: Dict[str, int]
+    round_winner: SimulationPlayer
+
+
+class BaseStrategy(Protocol):
+    key: str
+
+    def choose_score(self, player: SimulationPlayer, round_number: int) -> int:
+        ...
+
+
+class BaseEventHook(Protocol):
+    def handle(self, event: SimulationEvent, payload: Dict[str, object]) -> None:
+        ...
+
+
+_STRATEGIES: Dict[str, BaseStrategy] = {}
+_HOOKS: List[BaseEventHook] = []
+
+
+def register_strategy(strategy: BaseStrategy) -> None:
+    _STRATEGIES[strategy.key] = strategy
+
+
+def get_registered_strategies() -> Dict[str, BaseStrategy]:
+    return dict(_STRATEGIES)
+
+
+def register_hook(hook: BaseEventHook) -> None:
+    _HOOKS.append(hook)
+
+
+def _dispatch_event(event: SimulationEvent, payload: Dict[str, object]) -> None:
+    for hook in _HOOKS:
+        hook.handle(event, payload)
+
+
+class SimulationEngine:
+    def __init__(
+        self,
+        players: Iterable[SimulationPlayer],
+        rounds: int = 5,
+        strategy_registry: Optional[Dict[str, BaseStrategy]] = None,
+        hooks: Optional[List[BaseEventHook]] = None,
+    ) -> None:
+        self.players = list(players)
+        self.rounds = rounds
+        self.strategy_registry = strategy_registry or _STRATEGIES
+        self.hooks = hooks or _HOOKS
+        self._notify = _dispatch_event if hooks is None else self._make_dispatcher()
+        self._notify(SimulationEvent.INITIALIZED, {"players": self.players, "rounds": rounds})
+
+    def _make_dispatcher(self) -> Callable[[SimulationEvent, Dict[str, object]], None]:
+        def _dispatcher(event: SimulationEvent, payload: Dict[str, object]) -> None:
+            for hook in self.hooks:
+                hook.handle(event, payload)
+
+        return _dispatcher
+
+    def run(self) -> SimulationResult:
+        for player in self.players:
+            if player.strategy_key not in self.strategy_registry:
+                raise ValueError(f"Strategy '{player.strategy_key}' is not registered")
+            self._notify(SimulationEvent.PLAYER_REGISTERED, {"player": player})
+
+        scores = {player.name: 0 for player in self.players}
+        rounds_played: List[SimulationRound] = []
+
+        self._notify(SimulationEvent.GAME_STARTED, {"players": self.players})
+        for round_number in range(1, self.rounds + 1):
+            self._notify(SimulationEvent.ROUND_STARTED, {"round": round_number})
+            round_scores: Dict[str, int] = {}
+            for player in self.players:
+                strategy = self.strategy_registry[player.strategy_key]
+                round_scores[player.name] = strategy.choose_score(player, round_number)
+                scores[player.name] += round_scores[player.name]
+
+            round_winner = max(self.players, key=lambda player: round_scores[player.name])
+            round_summary = SimulationRound(
+                number=round_number,
+                scores=round_scores,
+                round_winner=round_winner,
+            )
+            rounds_played.append(round_summary)
+            self._notify(
+                SimulationEvent.ROUND_COMPLETED,
+                {"round": round_summary, "round_scores": round_scores},
+            )
+
+        winner = max(self.players, key=lambda player: scores[player.name])
+        result = SimulationResult(winner=winner, rounds_played=self.rounds)
+        self._notify(
+            SimulationEvent.GAME_COMPLETED,
+            {"result": result, "scores": scores, "rounds": rounds_played},
+        )
+        return result
+
+
+@dataclass
+class SimulationMetrics:
+    user_wins: int = 0
+    total_games: int = 0
+    per_strategy_wins: Dict[str, int] = field(default_factory=dict)
+
+    def record_result(self, result: SimulationResult) -> None:
+        self.total_games += 1
+        self.per_strategy_wins[result.winner.strategy_key] = (
+            self.per_strategy_wins.get(result.winner.strategy_key, 0) + 1
+        )
+        if result.winner.is_user:
+            self.user_wins += 1
+
+    def win_percentage(self, strategy_key: Optional[str] = None) -> float:
+        if self.total_games == 0:
+            return 0.0
+        if strategy_key is None:
+            return self.user_wins / self.total_games * 100
+        return self.per_strategy_wins.get(strategy_key, 0) / self.total_games * 100

--- a/app/simulator/hooks.py
+++ b/app/simulator/hooks.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+from .engine import BaseEventHook, SimulationEvent, SimulationRound
+
+
+@dataclass
+class TimelineHook(BaseEventHook):
+    events: List[Dict[str, object]]
+
+    def handle(self, event: SimulationEvent, payload: Dict[str, object]) -> None:
+        record = {"event": event.value, "payload": payload}
+        if event == SimulationEvent.ROUND_COMPLETED:
+            round_summary = payload.get("round")
+            if isinstance(round_summary, SimulationRound):
+                record["payload"] = {
+                    "round": round_summary.number,
+                    "round_winner": round_summary.round_winner.name,
+                    "round_scores": payload.get("round_scores"),
+                }
+        self.events.append(record)

--- a/app/simulator/service.py
+++ b/app/simulator/service.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Dict, Iterable, List, Optional
+
+from .. import models
+from .engine import (
+    BaseEventHook,
+    BaseStrategy,
+    SimulationEngine,
+    SimulationMetrics,
+    SimulationPlayer,
+    get_registered_strategies,
+)
+from .hooks import TimelineHook
+from .strategies import AggressiveStrategy, ConservativeStrategy, RandomStrategy
+
+
+@dataclass(frozen=True)
+class SimulationAssignment:
+    player_id: int
+    name: str
+    strategy_key: str
+    is_user: bool
+
+
+@dataclass(frozen=True)
+class SimulationOutcome:
+    iterations: int
+    rounds: int
+    user_player_id: int
+    user_strategy: str
+    opponent_strategy: str
+    assignments: List[SimulationAssignment]
+    metrics: SimulationMetrics
+    timeline: Optional[List[Dict[str, object]]]
+
+
+def default_strategies() -> Dict[str, BaseStrategy]:
+    return {
+        "random": RandomStrategy(),
+        "conservative": ConservativeStrategy(),
+        "aggressive": AggressiveStrategy(),
+    }
+
+
+def _build_registry() -> Dict[str, BaseStrategy]:
+    registry = default_strategies()
+    registry.update(get_registered_strategies())
+    return registry
+
+
+def _build_assignments(
+    players: Iterable[models.Player],
+    user_player_id: int,
+    user_strategy: str,
+    opponent_strategy: str,
+    overrides: Dict[int, str],
+) -> List[SimulationAssignment]:
+    assignments: List[SimulationAssignment] = []
+    for player in players:
+        is_user = player.id == user_player_id
+        strategy_key = overrides.get(
+            player.id,
+            user_strategy if is_user else opponent_strategy,
+        )
+        assignments.append(
+            SimulationAssignment(
+                player_id=player.id,
+                name=player.name,
+                strategy_key=strategy_key,
+                is_user=is_user,
+            )
+        )
+    return assignments
+
+
+def run_simulation(
+    players: Iterable[models.Player],
+    user_player_id: int,
+    user_strategy: str,
+    opponent_strategy: str,
+    overrides: Dict[int, str],
+    iterations: int,
+    rounds: int,
+    include_timeline: bool = False,
+) -> SimulationOutcome:
+    assignments = _build_assignments(
+        players=players,
+        user_player_id=user_player_id,
+        user_strategy=user_strategy,
+        opponent_strategy=opponent_strategy,
+        overrides=overrides,
+    )
+    registry = _build_registry()
+    metrics = SimulationMetrics()
+    timeline_events: Optional[List[Dict[str, object]]] = [] if include_timeline else None
+    hooks: Optional[List[BaseEventHook]] = None
+    if include_timeline:
+        hooks = [TimelineHook(events=timeline_events or [])]
+
+    for _ in range(iterations):
+        simulation_players = [
+            SimulationPlayer(
+                name=f\"{assignment.name}#{assignment.player_id}\",
+                strategy_key=assignment.strategy_key,
+                is_user=assignment.is_user,
+            )
+            for assignment in assignments
+        ]
+        engine = SimulationEngine(
+            players=simulation_players,
+            rounds=rounds,
+            strategy_registry=registry,
+            hooks=hooks,
+        )
+        result = engine.run()
+        metrics.record_result(result)
+
+    return SimulationOutcome(
+        iterations=iterations,
+        rounds=rounds,
+        user_player_id=user_player_id,
+        user_strategy=user_strategy,
+        opponent_strategy=opponent_strategy,
+        assignments=assignments,
+        metrics=metrics,
+        timeline=timeline_events,
+    )
+
+
+def serialize_assignments(assignments: Iterable[SimulationAssignment]) -> List[Dict[str, object]]:
+    return [asdict(assignment) for assignment in assignments]

--- a/app/simulator/strategies.py
+++ b/app/simulator/strategies.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+from .engine import BaseStrategy, SimulationPlayer
+
+
+@dataclass(frozen=True)
+class RandomStrategy:
+    key: str = "random"
+    min_score: int = 1
+    max_score: int = 6
+
+    def choose_score(self, player: SimulationPlayer, round_number: int) -> int:
+        return random.randint(self.min_score, self.max_score)
+
+
+@dataclass(frozen=True)
+class ConservativeStrategy:
+    key: str = "conservative"
+    fixed_score: int = 3
+
+    def choose_score(self, player: SimulationPlayer, round_number: int) -> int:
+        return self.fixed_score
+
+
+@dataclass(frozen=True)
+class AggressiveStrategy:
+    key: str = "aggressive"
+    base_score: int = 4
+
+    def choose_score(self, player: SimulationPlayer, round_number: int) -> int:
+        return self.base_score + (round_number % 2)


### PR DESCRIPTION
### Motivation

- Provide a generic game simulation framework to mark a given player as the user and measure win percentage against traditional strategies.
- Support a plugin-friendly architecture with strategy registration and event hooks so the simulator can be extended for AI methods and other use cases.

### Description

- Added `app/simulator/engine.py` which implements `SimulationEngine`, `SimulationEvent`, `SimulationPlayer`, `SimulationMetrics`, and registries plus `get_registered_strategies`/`register_strategy` APIs.
- Added default strategies in `app/simulator/strategies.py` (`RandomStrategy`, `ConservativeStrategy`, `AggressiveStrategy`) and an event `TimelineHook` in `app/simulator/hooks.py` to capture round events.
- Implemented `app/simulator/service.py` with `run_simulation`, `SimulationOutcome`, assignment serialization, and registry merging logic to run multiple iterations and aggregate metrics.
- Exposed a new FastAPI endpoint `POST /games/{game_id}/simulate` in `app/routers/simulation.py`, added request/response schemas (`SimulationRequest`, `SimulationResponse`, `SimulationOverride`, `SimulationAssignmentOut`) to `app/schemas.py`, and wired the router into `app/main.py`.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481b7452508330afd0c644b77e2fb9)