### PR TITLE
Add inference engine for deterministic card deductions

### DIFF
--- a/app/inference/__init__.py
+++ b/app/inference/__init__.py
@@ -1,0 +1,3 @@
+from .engine import CardInferenceEngine, CardKnowledge, KnowledgeType
+
+__all__ = ["CardInferenceEngine", "CardKnowledge", "KnowledgeType"]

--- a/app/inference/engine.py
+++ b/app/inference/engine.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, Iterable, List, Set
+
+
+class KnowledgeType(str, Enum):
+    HAS_CARD = "has_card"
+    DOES_NOT_HAVE_CARD = "does_not_have_card"
+
+
+@dataclass(frozen=True)
+class CardKnowledge:
+    player: str
+    card: str
+    knowledge: KnowledgeType
+
+
+@dataclass
+class CardInferenceEngine:
+    _has_cards: Dict[str, Set[str]] = field(default_factory=dict)
+    _not_cards: Dict[str, Set[str]] = field(default_factory=dict)
+
+    def record_card_shown(self, player: str, card: str) -> None:
+        if card in self._not_cards.get(player, set()):
+            raise ValueError(
+                f"Conflicting deduction: {player} cannot both have and not have {card}."
+            )
+        self._has_cards.setdefault(player, set()).add(card)
+
+    def record_cannot_show(self, player: str, cards: Iterable[str]) -> None:
+        for card in cards:
+            if card in self._has_cards.get(player, set()):
+                raise ValueError(
+                    f"Conflicting deduction: {player} already confirmed holding {card}."
+                )
+            self._not_cards.setdefault(player, set()).add(card)
+
+    def knowledge_for_player(self, player: str) -> List[CardKnowledge]:
+        has_cards = [
+            CardKnowledge(player=player, card=card, knowledge=KnowledgeType.HAS_CARD)
+            for card in sorted(self._has_cards.get(player, set()))
+        ]
+        not_cards = [
+            CardKnowledge(
+                player=player,
+                card=card,
+                knowledge=KnowledgeType.DOES_NOT_HAVE_CARD,
+            )
+            for card in sorted(self._not_cards.get(player, set()))
+        ]
+        return has_cards + not_cards
+
+    def all_knowledge(self) -> List[CardKnowledge]:
+        players = set(self._has_cards.keys()) | set(self._not_cards.keys())
+        combined: List[CardKnowledge] = []
+        for player in sorted(players):
+            combined.extend(self.knowledge_for_player(player))
+        return combined

--- a/app/simulator/service.py
+++ b/app/simulator/service.py
@@ -102,7 +102,7 @@ def run_simulation(
     for _ in range(iterations):
         simulation_players = [
             SimulationPlayer(
-                name=f\"{assignment.name}#{assignment.player_id}\",
+                name=f"{assignment.name}#{assignment.player_id}",
                 strategy_key=assignment.strategy_key,
                 is_user=assignment.is_user,
             )

--- a/tests/test_inference_rules.py
+++ b/tests/test_inference_rules.py
@@ -1,0 +1,22 @@
+from app.inference.engine import CardInferenceEngine, KnowledgeType
+
+
+def test_player_showing_card_is_in_hand() -> None:
+    engine = CardInferenceEngine()
+
+    engine.record_card_shown("Avery", "Rope")
+
+    knowledge = engine.knowledge_for_player("Avery")
+    assert len(knowledge) == 1
+    assert knowledge[0].card == "Rope"
+    assert knowledge[0].knowledge == KnowledgeType.HAS_CARD
+
+
+def test_player_cannot_show_means_no_suggested_cards() -> None:
+    engine = CardInferenceEngine()
+
+    engine.record_cannot_show("Blake", ["Knife", "Library", "Plum"])
+
+    knowledge = engine.knowledge_for_player("Blake")
+    assert [entry.card for entry in knowledge] == ["Knife", "Library", "Plum"]
+    assert all(entry.knowledge == KnowledgeType.DOES_NOT_HAVE_CARD for entry in knowledge)


### PR DESCRIPTION
### Motivation
- Capture deterministic Clue-like deductions such as when a player shows a card it must be in their hand and when a player cannot show on a suggestion none of the suggested cards are in their hand.  
- Provide a dedicated inference component to compute/store these facts for downstream UI and APIs.  
- Keep deductions simple and computable on read to avoid schema churn and to enable deterministic reasoning.  
- Fix a syntax issue that prevented test imports so inference tests can run.

### Description
- Add `app/inference/engine.py` implementing `CardInferenceEngine`, `CardKnowledge`, and `KnowledgeType` for in-memory deduction tracking.  
- Expose the inference API via `app/inference/__init__.py` so other modules can import `CardInferenceEngine`.  
- Add unit tests in `tests/test_inference_rules.py` that validate the two rules (`record_card_shown` and `record_cannot_show`).  
- Fix a malformed f-string in `app/simulator/service.py` that caused import-time failures.

### Testing
- Ran `pytest tests/test_inference_rules.py`.  
- The tests completed successfully with `2 passed` and no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481f0327d483309d197aa218e8d7e1)