### PR TITLE
Add game knowledge endpoint backed by inference engine

### DIFF
--- a/app/knowledge.py
+++ b/app/knowledge.py
@@ -1,0 +1,144 @@
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Set
+
+from sqlalchemy.orm import Session
+
+from . import models
+
+
+@dataclass(frozen=True)
+class CardKnowledge:
+    card_id: int
+    name: str
+    category: str
+    owner_player_id: Optional[int]
+    owner_known: bool
+
+
+@dataclass(frozen=True)
+class PlayerKnowledge:
+    player_id: int
+    name: str
+    confirmed_card_ids: List[int]
+    possible_card_ids: List[int]
+
+
+@dataclass(frozen=True)
+class EnvelopePossibilities:
+    suspects: List[int]
+    weapons: List[int]
+    rooms: List[int]
+
+
+@dataclass(frozen=True)
+class KnowledgeSnapshot:
+    cards: List[CardKnowledge]
+    players: List[PlayerKnowledge]
+    envelope: EnvelopePossibilities
+
+
+def _build_known_owners(
+    player_cards: Iterable[models.PlayerCard],
+    responses: Iterable[models.SuggestionResponse],
+) -> Dict[int, int]:
+    known_owners: Dict[int, int] = {}
+    for player_card in player_cards:
+        known_owners[player_card.card_id] = player_card.player_id
+    for response in responses:
+        if response.shown_card_id and response.shower_id:
+            known_owners[response.shown_card_id] = response.shower_id
+    return known_owners
+
+
+def _build_possible_cards_by_player(
+    responses: Iterable[models.SuggestionResponse],
+) -> Dict[int, Set[int]]:
+    possible_cards: Dict[int, Set[int]] = {}
+    for response in responses:
+        if response.shower_id and response.shown_card_id is None:
+            suggestion = response.suggestion
+            possible_cards.setdefault(response.shower_id, set()).update(
+                [
+                    suggestion.suspect_card_id,
+                    suggestion.weapon_card_id,
+                    suggestion.room_card_id,
+                ]
+            )
+    return possible_cards
+
+
+def build_game_knowledge(db: Session, game_id: int) -> KnowledgeSnapshot:
+    players = (
+        db.query(models.Player)
+        .filter(models.Player.game_id == game_id)
+        .order_by(models.Player.seat_order.asc())
+        .all()
+    )
+    cards = db.query(models.Card).order_by(models.Card.id.asc()).all()
+    player_cards = (
+        db.query(models.PlayerCard)
+        .filter(models.PlayerCard.game_id == game_id)
+        .all()
+    )
+    responses = (
+        db.query(models.SuggestionResponse)
+        .join(models.Suggestion)
+        .filter(models.Suggestion.game_id == game_id)
+        .all()
+    )
+
+    known_owners = _build_known_owners(player_cards, responses)
+    possible_cards_by_player = _build_possible_cards_by_player(responses)
+    for card_id, owner_id in known_owners.items():
+        for player_id, possible_cards in possible_cards_by_player.items():
+            if player_id != owner_id:
+                possible_cards.discard(card_id)
+
+    cards_by_id = {card.id: card for card in cards}
+
+    card_knowledge: List[CardKnowledge] = [
+        CardKnowledge(
+            card_id=card.id,
+            name=card.name,
+            category=card.category,
+            owner_player_id=known_owners.get(card.id),
+            owner_known=card.id in known_owners,
+        )
+        for card in cards
+    ]
+
+    player_knowledge: List[PlayerKnowledge] = []
+    for player in players:
+        confirmed = sorted(
+            card_id for card_id, owner_id in known_owners.items() if owner_id == player.id
+        )
+        possible = sorted(
+            card_id
+            for card_id in possible_cards_by_player.get(player.id, set())
+            if card_id not in confirmed
+        )
+        player_knowledge.append(
+            PlayerKnowledge(
+                player_id=player.id,
+                name=player.name,
+                confirmed_card_ids=confirmed,
+                possible_card_ids=possible,
+            )
+        )
+
+    def _by_category(category: str) -> List[int]:
+        return sorted(
+            card.id for card in cards if card.category == category and card.id not in known_owners
+        )
+
+    envelope = EnvelopePossibilities(
+        suspects=_by_category("suspect"),
+        weapons=_by_category("weapon"),
+        rooms=_by_category("room"),
+    )
+
+    return KnowledgeSnapshot(
+        cards=card_knowledge,
+        players=player_knowledge,
+        envelope=envelope,
+    )

--- a/app/models.py
+++ b/app/models.py
@@ -66,3 +66,65 @@ class Player(Base):
                         nullable=False, server_default=text('CURRENT_TIMESTAMP'))
 
     game = relationship("Game", back_populates="players")
+
+
+class Card(Base):
+    __tablename__ = "cards"
+
+    id = Column(Integer, primary_key=True, nullable=False)
+    name = Column(String, nullable=False)
+    category = Column(String, nullable=False)
+
+
+class PlayerCard(Base):
+    __tablename__ = "player_cards"
+
+    id = Column(Integer, primary_key=True, nullable=False)
+    game_id = Column(Integer, ForeignKey(
+        "games.id", ondelete="CASCADE"), nullable=False)
+    player_id = Column(Integer, ForeignKey(
+        "players.id", ondelete="CASCADE"), nullable=False)
+    card_id = Column(Integer, ForeignKey(
+        "cards.id", ondelete="CASCADE"), nullable=False)
+
+    player = relationship("Player")
+    card = relationship("Card")
+
+
+class Suggestion(Base):
+    __tablename__ = "suggestions"
+
+    id = Column(Integer, primary_key=True, nullable=False)
+    game_id = Column(Integer, ForeignKey(
+        "games.id", ondelete="CASCADE"), nullable=False)
+    suggester_id = Column(Integer, ForeignKey(
+        "players.id", ondelete="CASCADE"), nullable=False)
+    suspect_card_id = Column(Integer, ForeignKey(
+        "cards.id", ondelete="CASCADE"), nullable=False)
+    weapon_card_id = Column(Integer, ForeignKey(
+        "cards.id", ondelete="CASCADE"), nullable=False)
+    room_card_id = Column(Integer, ForeignKey(
+        "cards.id", ondelete="CASCADE"), nullable=False)
+    created_at = Column(TIMESTAMP(timezone=True),
+                        nullable=False, server_default=text('CURRENT_TIMESTAMP'))
+
+    suggester = relationship("Player")
+    suspect_card = relationship("Card", foreign_keys=[suspect_card_id])
+    weapon_card = relationship("Card", foreign_keys=[weapon_card_id])
+    room_card = relationship("Card", foreign_keys=[room_card_id])
+
+
+class SuggestionResponse(Base):
+    __tablename__ = "suggestion_responses"
+
+    id = Column(Integer, primary_key=True, nullable=False)
+    suggestion_id = Column(Integer, ForeignKey(
+        "suggestions.id", ondelete="CASCADE"), nullable=False)
+    shower_id = Column(Integer, ForeignKey(
+        "players.id", ondelete="SET NULL"), nullable=True)
+    shown_card_id = Column(Integer, ForeignKey(
+        "cards.id", ondelete="SET NULL"), nullable=True)
+
+    suggestion = relationship("Suggestion")
+    shower = relationship("Player")
+    shown_card = relationship("Card")

--- a/app/routers/game.py
+++ b/app/routers/game.py
@@ -3,7 +3,7 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
-from .. import models, schemas, oauth2
+from .. import models, schemas, oauth2, knowledge
 from ..database import get_db
 
 
@@ -90,3 +90,50 @@ def list_players(
     if game.owner_id != current_user.id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to view this game")
     return db.query(models.Player).filter(models.Player.game_id == game_id).order_by(models.Player.seat_order.asc()).all()
+
+
+@router.get("/{game_id}/knowledge", response_model=schemas.GameKnowledgeOut)
+def get_game_knowledge(
+    game_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(oauth2.get_current_user),
+):
+    game = db.query(models.Game).filter(models.Game.id == game_id).first()
+    if not game:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
+    if game.owner_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to view this game")
+
+    snapshot = knowledge.build_game_knowledge(db, game_id)
+    cards_by_id = {card.id: card for card in db.query(models.Card).all()}
+
+    def card_ref(card_id: int) -> schemas.CardRef:
+        card = cards_by_id[card_id]
+        return schemas.CardRef(id=card.id, name=card.name, category=card.category)
+
+    return schemas.GameKnowledgeOut(
+        cards=[
+            schemas.CardKnowledgeOut(
+                id=card.card_id,
+                name=card.name,
+                category=card.category,
+                owner_player_id=card.owner_player_id,
+                owner_known=card.owner_known,
+            )
+            for card in snapshot.cards
+        ],
+        players=[
+            schemas.PlayerKnowledgeOut(
+                player_id=player.player_id,
+                name=player.name,
+                confirmed_cards=[card_ref(card_id) for card_id in player.confirmed_card_ids],
+                possible_cards=[card_ref(card_id) for card_id in player.possible_card_ids],
+            )
+            for player in snapshot.players
+        ],
+        envelope_possibilities=schemas.EnvelopePossibilitiesOut(
+            suspects=[card_ref(card_id) for card_id in snapshot.envelope.suspects],
+            weapons=[card_ref(card_id) for card_id in snapshot.envelope.weapons],
+            rooms=[card_ref(card_id) for card_id in snapshot.envelope.rooms],
+        ),
+    )

--- a/app/routers/post.py
+++ b/app/routers/post.py
@@ -121,5 +121,6 @@ def update_post(id: int, updated_post: schemas.PostUpdate, db: Session = Depends
         post_query.update(update_data, synchronize_session=False)
 
     db.commit()
+    db.refresh(post)
 
-    return post_query.first()
+    return post

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -145,3 +145,33 @@ class SimulationResponse(BaseModel):
     strategy_win_counts: dict
     assignments: List[SimulationAssignmentOut]
     timeline: Optional[List[dict]] = None
+
+
+class CardRef(BaseModel):
+    id: int
+    name: str
+    category: str
+
+
+class CardKnowledgeOut(CardRef):
+    owner_player_id: Optional[int]
+    owner_known: bool
+
+
+class PlayerKnowledgeOut(BaseModel):
+    player_id: int
+    name: str
+    confirmed_cards: List[CardRef]
+    possible_cards: List[CardRef]
+
+
+class EnvelopePossibilitiesOut(BaseModel):
+    suspects: List[CardRef]
+    weapons: List[CardRef]
+    rooms: List[CardRef]
+
+
+class GameKnowledgeOut(BaseModel):
+    cards: List[CardKnowledgeOut]
+    players: List[PlayerKnowledgeOut]
+    envelope_possibilities: EnvelopePossibilitiesOut

--- a/app/simulator/service.py
+++ b/app/simulator/service.py
@@ -102,7 +102,7 @@ def run_simulation(
     for _ in range(iterations):
         simulation_players = [
             SimulationPlayer(
-                name=f\"{assignment.name}#{assignment.player_id}\",
+                name=f"{assignment.name}#{assignment.player_id}",
                 strategy_key=assignment.strategy_key,
                 is_user=assignment.is_user,
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 alembic==1.13.2
 email-validator==2.1.0.post1
 fastapi==0.99.1
+httpx==0.27.0
 Jinja2==3.1.4
 passlib[bcrypt]==1.7.4
+bcrypt==3.2.2
 psycopg2==2.9.9
 pydantic==1.10.15
 pytest==8.3.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
 engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
 
 TestingSessionLocal = sessionmaker(
-    autocommit=False, autoflush=False, bind=engine)
+    autocommit=False, autoflush=False, bind=engine, expire_on_commit=False)
 
 
 @pytest.fixture()

--- a/tests/database.py
+++ b/tests/database.py
@@ -14,7 +14,7 @@ SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
 engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
 
 TestingSessionLocal = sessionmaker(
-    autocommit=False, autoflush=False, bind=engine)
+    autocommit=False, autoflush=False, bind=engine, expire_on_commit=False)
 
 
 @pytest.fixture()

--- a/tests/test_game_knowledge.py
+++ b/tests/test_game_knowledge.py
@@ -1,0 +1,117 @@
+from app import models
+
+
+def test_game_knowledge_inference(authorized_client, session):
+    game_res = authorized_client.post("/games/", json={"name": "Deduction Night"})
+    assert game_res.status_code == 201
+    game_id = game_res.json()["id"]
+
+    authorized_client.post(
+        f"/games/{game_id}/players",
+        json={"name": "Alex", "seat_order": 1},
+    )
+    authorized_client.post(
+        f"/games/{game_id}/players",
+        json={"name": "Blake", "seat_order": 2},
+    )
+    authorized_client.post(
+        f"/games/{game_id}/players",
+        json={"name": "Casey", "seat_order": 3},
+    )
+
+    players = (
+        session.query(models.Player)
+        .filter(models.Player.game_id == game_id)
+        .order_by(models.Player.seat_order.asc())
+        .all()
+    )
+    player_by_name = {player.name: player for player in players}
+
+    cards = [
+        models.Card(name="Scarlet", category="suspect"),
+        models.Card(name="Mustard", category="suspect"),
+        models.Card(name="Knife", category="weapon"),
+        models.Card(name="Revolver", category="weapon"),
+        models.Card(name="Kitchen", category="room"),
+        models.Card(name="Library", category="room"),
+    ]
+    session.add_all(cards)
+    session.commit()
+    cards_by_name = {card.name: card for card in session.query(models.Card).all()}
+
+    session.add_all(
+        [
+            models.PlayerCard(
+                game_id=game_id,
+                player_id=player_by_name["Alex"].id,
+                card_id=cards_by_name["Scarlet"].id,
+            ),
+            models.PlayerCard(
+                game_id=game_id,
+                player_id=player_by_name["Blake"].id,
+                card_id=cards_by_name["Knife"].id,
+            ),
+            models.PlayerCard(
+                game_id=game_id,
+                player_id=player_by_name["Casey"].id,
+                card_id=cards_by_name["Kitchen"].id,
+            ),
+        ]
+    )
+    session.commit()
+
+    suggestion_one = models.Suggestion(
+        game_id=game_id,
+        suggester_id=player_by_name["Alex"].id,
+        suspect_card_id=cards_by_name["Mustard"].id,
+        weapon_card_id=cards_by_name["Revolver"].id,
+        room_card_id=cards_by_name["Library"].id,
+    )
+    session.add(suggestion_one)
+    session.commit()
+    session.add(
+        models.SuggestionResponse(
+            suggestion_id=suggestion_one.id,
+            shower_id=player_by_name["Blake"].id,
+            shown_card_id=cards_by_name["Revolver"].id,
+        )
+    )
+    session.commit()
+
+    suggestion_two = models.Suggestion(
+        game_id=game_id,
+        suggester_id=player_by_name["Casey"].id,
+        suspect_card_id=cards_by_name["Mustard"].id,
+        weapon_card_id=cards_by_name["Revolver"].id,
+        room_card_id=cards_by_name["Library"].id,
+    )
+    session.add(suggestion_two)
+    session.commit()
+    session.add(
+        models.SuggestionResponse(
+            suggestion_id=suggestion_two.id,
+            shower_id=player_by_name["Alex"].id,
+            shown_card_id=None,
+        )
+    )
+    session.commit()
+
+    knowledge_res = authorized_client.get(f"/games/{game_id}/knowledge")
+    assert knowledge_res.status_code == 200
+    knowledge = knowledge_res.json()
+
+    card_by_name = {card["name"]: card for card in knowledge["cards"]}
+    assert card_by_name["Revolver"]["owner_known"] is True
+    assert card_by_name["Revolver"]["owner_player_id"] == player_by_name["Blake"].id
+    assert card_by_name["Mustard"]["owner_known"] is False
+
+    players_by_name = {player["name"]: player for player in knowledge["players"]}
+    alex_confirmed = {card["name"] for card in players_by_name["Alex"]["confirmed_cards"]}
+    alex_possible = {card["name"] for card in players_by_name["Alex"]["possible_cards"]}
+    assert alex_confirmed == {"Scarlet"}
+    assert alex_possible == {"Mustard", "Library"}
+
+    envelope = knowledge["envelope_possibilities"]
+    assert {card["name"] for card in envelope["suspects"]} == {"Mustard"}
+    assert envelope["weapons"] == []
+    assert {card["name"] for card in envelope["rooms"]} == {"Library"}


### PR DESCRIPTION
### Motivation
- Surface the inference engine’s deductions through a read-only API so clients can consume consistent per-card, per-player, and envelope knowledge. 
- Introduce domain models for cards, hands and suggestions so deductions are based on authoritative game events. 
- Provide an integration test that reproduces realistic suggestion/showing sequences to validate the inference logic. 
- Ensure tests run reliably by addressing missing test deps and session refresh semantics.

### Description
- Added card and suggestion models (`Card`, `PlayerCard`, `Suggestion`, `SuggestionResponse`) in `app/models.py` to represent cards, dealt hands and suggestion events. 
- Implemented the inference snapshot builder `build_game_knowledge` in `app/knowledge.py` that returns per-card ownership info, per-player confirmed/possible cards, and envelope possibilities. 
- Exposed `GET /games/{game_id}/knowledge` in `app/routers/game.py` and added corresponding response schemas (`CardRef`, `CardKnowledgeOut`, `PlayerKnowledgeOut`, `EnvelopePossibilitiesOut`, `GameKnowledgeOut`) in `app/schemas.py`. 
- Added integration test `tests/test_game_knowledge.py`, pinned `httpx` and `bcrypt` in `requirements.txt`, fixed a simulation f-string, and made session/refresh improvements (`expire_on_commit=False` and `db.refresh` where needed).

### Testing
- Ran the full test suite with `pytest` and confirmed all automated tests passed. 
- The new integration test `tests/test_game_knowledge.py` executes a multi-player scenario and validates derived knowledge from suggestions and responses. 
- Dependency additions (`httpx`, `bcrypt`) were installed to support the test client and password hashing. 
- Test run summary: `38 passed` (no failing automated tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481f04613c83309847943349190ccf)